### PR TITLE
Missing import on core-overlay-layer.html

### DIFF
--- a/core-overlay-layer.html
+++ b/core-overlay-layer.html
@@ -7,6 +7,8 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
+<link rel="import" href="../polymer/polymer.html">
+
 <polymer-element name="core-overlay-layer">
 <template>
   <style>


### PR DESCRIPTION
This missing import causes a big ugly error in polymer.dart.  
