### PR TITLE
Check getTransition(old) return value

### DIFF
--- a/core-overlay.html
+++ b/core-overlay.html
@@ -309,7 +309,10 @@ object like this: `{v: 'top', h: 'right'}`.
         return;
       }
       if (old) {
-        this.getTransition(old).teardown(this.target);
+        var transition = this.getTransition(old);
+        if (transition) {
+          transition.teardown(this.target);
+        }
       }
       this.target.__overlaySetup = false;
     },


### PR DESCRIPTION
This works around

```
TypeError: Cannot read property 'teardown' of undefined
at core-overlay.Polymer.transitionChanged (http://jeffposnick.github.io/pageable-text/components/core-overlay/core-overlay.html:312:32)
```

runtime exceptions that I see in [this demo](http://jeffposnick.github.io/pageable-text/components/pageable-text/demo.html).

I'm not using `<core-overlay>` directly, and I assume the errors come from using `<paper-dialog>`. The value of `old` is `"core-transition-fade"` when this exception is thrown.
