### PR TITLE
Update resetTargetDimensions to fix error

### DIFF
--- a/core-overlay.html
+++ b/core-overlay.html
@@ -571,11 +571,11 @@ object like this: `{v: 'top', h: 'right'}`.
     },
 
     resetTargetDimensions: function() {
-      if (!this.dimensions.size.v) {
+      if (!this.dimensions || !this.dimensions.size.v) {
         this.sizingTarget.style.maxHeight = '';  
         this.target.style.top = '';
       }
-      if (!this.dimensions.size.h) {
+      if (!this.dimensions || !this.dimensions.size.h) {
         this.sizingTarget.style.maxWidth = '';  
         this.target.style.left = '';
       }


### PR DESCRIPTION
This function can get called when dimensions are null, resulting in an error. See https://github.com/dart-lang/paper-elements/issues/58 for the original report . The repro contained in that issue basically just opens two paper-toasts a few milliseconds apart.
