### PR TITLE
incorrect doc, core-overlay-open event detail.

### DIFF
--- a/core-overlay.html
+++ b/core-overlay.html
@@ -70,7 +70,7 @@ Fired when the `core-overlay`'s `opened` property changes.
 
 @event core-overlay-open
 @param {Object} detail
-@param {Object} detail.opened the opened state
+@param {Object} detail the opened state
 -->
 <!--
 Fired when the `core-overlay` has completely opened.


### PR DESCRIPTION
`event.detail` is a boolean and not a object with an "opened" property
cf the `openedChanged` callback (line 366):

```javascript
this.fire('core-overlay-open', this.opened);
```

Company-CLA signed : Hewlett-Packard