### PR TITLE
Return closed dialog to it's original position

### DIFF
--- a/core-overlay-layer.html
+++ b/core-overlay-layer.html
@@ -101,7 +101,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
       if (element.__parentNode) {
         var n = element.__nextElementSibling && element.__nextElementSibling 
-            === element.__parentNode ? element.__nextElementSibling : null;
+            !== element.__parentNode ? element.__nextElementSibling : null;
         element.__parentNode.insertBefore(element, n);
       }
     },


### PR DESCRIPTION
The next sibling should not be the same as the parent, but because we're checking whether or not they're the same, the element is being appended into the parent rather than re-inserted where it was.