### PR TITLE
Fix error when parent is null in core-overlay

### DIFF
--- a/core-overlay-layer.html
+++ b/core-overlay-layer.html
@@ -88,7 +88,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       element.eventController = null;
       this.replaceElement(element);
       var h = element.__host;
-      if (h) {
+      if (h && h.parentNode) {
         h.parentNode.removeChild(h);
       }
     },

--- a/core-overlay.html
+++ b/core-overlay.html
@@ -454,7 +454,7 @@ object like this: `{v: 'top', h: 'right'}`.
     completeBackdrop: function() {
       if (this.backdrop) {
         trackBackdrop(this);
-        if (getBackdrops().length === 0) {
+        if (getBackdrops().length === 0 && this.scrim.parentNode) {
           this.scrim.parentNode.removeChild(this.scrim);
         }
       }


### PR DESCRIPTION
When unit testing a component using `paper-action-dialog`, the test fails when opened is toggled on the element with the following errors:

`core-overlay.html:458:
Uncaught TypeError: Cannot read property 'removeChild' of null`

and subsequently when the above error was addressed:

`core-overlay-layer.html:92:
Uncaught TypeError: Cannot read property 'removeChild' of null`

these errors seem to correspond to the issue reported here:
https://github.com/dart-lang/paper-elements/issues/83
